### PR TITLE
Adding support for KCLS

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -302,6 +302,10 @@
     site: 'bibliocommons',
     url: 'http://seattle.bibliocommons.com/search?t=smart&q=' 
   }, {
+    name: 'King County Library System',
+    site: 'bibliocommons',
+    url: 'http://kcls.bibliocommons.com/search?t=smart&q=' 
+  }, {
     name: 'Fathom',
     site: 'letsfathom',
     url: function(artist, title) {


### PR DESCRIPTION
As far as I can tell this is all it will take to resolve #6 ? I tested locally and it worked from Amazon -> KCLS.

@iangilman - The full name "King County Library System" is a bit long, would you prefer "KCLS" as the display string, or do you think that will be too hard to discover?
